### PR TITLE
Replace self-hosted runner with ubuntu-latest

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   print-branch-info:
     if: github.event.pull_request.merged == true
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Print Branch Information
         run: |


### PR DESCRIPTION
## Summary
- Updated workflow to use GitHub-hosted runner instead of self-hosted

## Changes
- Changed `runs-on: self-hosted` to `runs-on: ubuntu-latest`